### PR TITLE
Start health-hal service in tree

### DIFF
--- a/recovery/root/init.recovery.mt6853.rc
+++ b/recovery/root/init.recovery.mt6853.rc
@@ -10,6 +10,9 @@ on fs
     install_keyring
     setprop crypto.ready 1
 
+on boot
+    start health-hal-2-0
+
 service keystore_auth /system/bin/keystore_auth
     oneshot
     user root


### PR DESCRIPTION
Since it behaviour from https://github.com/TeamWin/android_bootable_recovery/commit/2bf400c47c6dd7ba1514145dd45ecc4c3d8ccedc